### PR TITLE
New options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EXECUTABLE=debugedit
 
 all: $(SOURCES) $(EXECUTABLE)
 clean: 
-	rm -f *.o *.exe
+	rm -f $(OBJECTS) *.exe $(EXECUTABLE)
 	
 $(EXECUTABLE): $(SOURCES)
 	$(CC) -o $@ $(SOURCES) $(CFLAGS) 


### PR DESCRIPTION
Add two new options:
 --files-only (-f) to only emit file names, not directories into the list file;

 --quiet (-q) to not dump lot of stuff into the standard output.

Cleanup "clean" target while I am here.